### PR TITLE
[FIX]: 계정 수치 데이터 연결 완료 - 댓글 연결 ❌

### DIFF
--- a/MyTube/MyTube/Managers/YoutubeManger.swift
+++ b/MyTube/MyTube/Managers/YoutubeManger.swift
@@ -18,7 +18,7 @@ final class YoutubeManger {
             "type": "video",
             "page": "\(page)",
             "maxResults": "20",
-            "key": HANS_KEY
+            "key": TEST4_KEY
         ]
         
         if let searchText = searchText {
@@ -44,7 +44,7 @@ final class YoutubeManger {
             "part": "snippet",
             "videoId": "\(videoId)",
             "maxResults": "10",
-            "key": TEST2_KEY
+            "key": TEST4_KEY
         ]
         
         AF.request(CommentURL, method: .get, parameters: params).response { response in
@@ -69,7 +69,7 @@ final class YoutubeManger {
             "part": "snippet,contentDetails,statistics",
             "id": channelID,
             "fields": "items/snippet/thumbnails",
-            "key": HANS_KEY
+            "key": TEST4_KEY
         ]
         let dataTask = AF.request(ChannelURL, method: .get, parameters: params)
             .serializingDecodable(ProfileThumbnail.self)
@@ -88,7 +88,7 @@ final class YoutubeManger {
         let params = [
             "part": "snippet,contentDetails,statistics",
             "id": channelID,
-            "key": HANS_KEY
+            "key": TEST4_KEY
         ]
         
         let dataTask = AF.request(ChannelURL, method: .get, parameters: params)

--- a/MyTube/MyTube/Models/Comments.swift
+++ b/MyTube/MyTube/Models/Comments.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct Comments: Codable {
-    let item: [Item]
+    let items: [Item]?
     
     // MARK: - Item
     struct Item: Codable {
         let snippet: ItemSnippet
     }
-
+    
     // MARK: - ItemSnippet
     struct ItemSnippet: Codable {
         let channelID, videoID: String?
@@ -22,20 +22,20 @@ struct Comments: Codable {
         let canReply: Bool?
         let totalReplyCount: Int?
         let isPublic: Bool?
-
+        
         enum CodingKeys: String, CodingKey {
             case channelID = "channelId"
             case videoID = "videoId"
             case topLevelComment, canReply, totalReplyCount, isPublic
         }
     }
-
+    
     // MARK: - TopLevelComment
     struct TopLevelComment: Codable {
         let kind, etag, id: String?
         let snippet: TopLevelCommentSnippet
     }
-
+    
     // MARK: - TopLevelCommentSnippet
     struct TopLevelCommentSnippet: Codable {
         let channelID, videoID, textDisplay, textOriginal: String?
@@ -47,7 +47,7 @@ struct Comments: Codable {
         let viewerRating: String?
         let likeCount: Int?
         let publishedAt, updatedAt: Date?
-
+        
         enum CodingKeys: String, CodingKey {
             case channelID = "channelId"
             case videoID = "videoId"
@@ -58,15 +58,14 @@ struct Comments: Codable {
             case canRate, viewerRating, likeCount, publishedAt, updatedAt
         }
     }
-
+    
     // MARK: - AuthorChannelID
     struct AuthorChannelID: Codable {
         let value: String
     }
-
+    
     // MARK: - PageInfo
     struct PageInfo: Codable {
         let totalResults, resultsPerPage: Int
     }
-
 }

--- a/MyTube/MyTube/Scenes/DetailPage/CommentTableViewController.swift
+++ b/MyTube/MyTube/Scenes/DetailPage/CommentTableViewController.swift
@@ -40,11 +40,16 @@ class CommentTableViewController: UIViewController {
         youtubeManager.getComments(from: videoId) { result in
             switch result {
             case .success(let comment):
-                print("댓글 출력 확인\(comment)")
-                self.commentData += comment.item
+                self.appendComments(data: comment.items)
             case .failure(let error):
                 print("오류 출력 확인\(error)")
             }
+        }
+    }
+    
+    func appendComments(data: [Comments.Item]?) {
+        if let items = data {
+            commentData += items
         }
     }
     
@@ -69,8 +74,7 @@ extension CommentTableViewController: UITableViewDataSource {
         let cell = commentTableView.dequeueReusableCell(withIdentifier: CommentCell.identifier, for: indexPath) as! CommentCell
         let comment = commentData[indexPath.row]
         cell.contentView.backgroundColor = .white
-        // MARK: - 댓글 연결 실패
-//        cell.commentLabel.text = comment.items.
+        cell.commentLabel.text = comment.snippet.topLevelComment.snippet.textDisplay
         return cell
     }
 }

--- a/MyTube/MyTube/Scenes/HomePage/HomeViewController.swift
+++ b/MyTube/MyTube/Scenes/HomePage/HomeViewController.swift
@@ -101,12 +101,6 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
         detailVC.configureData(url: url, data: data)
         UserDefaultManager.sharedInstance.saveCurrentVideo(videoId: data.id.videoId)
         navigationController?.pushViewController(detailVC, animated: true)
-        
-        Task {
-            let channelID = data.snippet.channelId
-            let channelInfo = await YoutubeManger.shared.getChannelInfo(channelID: channelID)
-            print("====> \(channelInfo)")
-        }
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {


### PR DESCRIPTION
1. 구독 버튼 클릭 시, 구독 버튼 컬러 변경되도록 설정
2.계정 수치 (구독자 수, 영상 조회 수) 데이터 연결 ✅
3. 댓글은 데이터 호출 및 저장이 되었으나 tableView를 채우지는 못함